### PR TITLE
Fixed connection to db in prod, dev and local

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,13 +24,22 @@ repositories {
 tasks.register("bootRunDev") {
     group = "application"
     description = "Runs the Spring Boot application with the dev profile"
+
     doFirst {
-        tasks.bootRun.configure {
+        val env = System.getenv()
+        val databaseUri = env.getOrDefault("DATABASE_URI", "no-database-specified")
+        val port = env.getOrDefault("PORT", "8080")
+
+        tasks.withType<org.springframework.boot.gradle.tasks.run.BootRun>().configureEach {
             systemProperty("spring.profiles.active", "dev")
+            environment("DATABASE_URI", databaseUri)
+            environment("PORT", port)
         }
     }
+
     finalizedBy("bootRun")
 }
+
 
 tasks.register("bootRunProd") {
     group = "application"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,7 @@ services:
     environment: # Used during container runtime. Read from .env
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}
       - PORT=${PORT}
-      - DATABASE_URL=mongodb://mongodb:${DB_PORT}/${DB_NAME}
-      - DB_USERNAME=${DB_USERNAME}
-      - DB_PASSWORD=${DB_PASSWORD}
+      - DATABASE_URI=mongodb://${DB_USERNAME}:${DB_PASSWORD}@mongodb:${DB_PORT}/admin?retryWrites=true&w=majority
     volumes:
       - ./src/main/resources:/app/config
     networks:
@@ -30,7 +28,7 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${DB_USERNAME}
       - MONGO_INITDB_ROOT_PASSWORD=${DB_PASSWORD}
-      - MONGO_INITDB_DATABASE=${DB_NAME}
+      - MONGO_INITDB_DATABASE=admin # Tiene que ser admin porque es donde crea el usuario que especificamos con las variables de arriba
     volumes:
       - mongo-data:/data/db
     networks:

--- a/env.example
+++ b/env.example
@@ -1,7 +1,17 @@
 # Deben setearse en Render para dev y prod
 PORT=8086
+SPRING_PROFILES_ACTIVE=dev / prod
+DATABASE_URI=
+
+# Deben setearse en el .env para correr local con el docker compose
+PORT=8086
+SPRING_PROFILES_ACTIVE=dev
 DB_USERNAME=user
 DB_PASSWORD=pass
-DB_NAME=buddy
+DB_NAME=admin
 DB_PORT=27017
+
+# Deben setearse en el .env para correr local con la db en atlas dev
+PORT=8086
 SPRING_PROFILES_ACTIVE=dev
+DATABASE_URI=

--- a/run_dev_atlas_db.sh
+++ b/run_dev_atlas_db.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export $(xargs <.env)
+
+./gradlew bootRunDev

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,2 +1,1 @@
-spring.data.mongodb.uri=mongodb+srv://userDevBuddy:passwordDev@buddy-dev.cetbbup.mongodb.net/?retryWrites=true&w=majority&appName=buddy-dev
-spring.data.mongodb.database=sample_mflix
+spring.data.mongodb.uri=${DATABASE_URI}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,2 +1,1 @@
-spring.data.mongodb.uri=mongodb+srv://userProdBuddy:passwordProd@buddy-prod.p3x54po.mongodb.net/?retryWrites=true&w=majority&appName=buddy-prod
-spring.data.mongodb.database=sample_mflix
+spring.data.mongodb.uri=${DATABASE_URI}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,9 +3,6 @@ spring.application.name=backend
 spring.threads.virtual.enabled=true
 
 server.port=${PORT:8080}
-spring.datasource.url = ${DB_HOST}:${DB_PORT}/${DB_NAME}
-spring.datasource.username = ${DB_USERNAME}
-spring.datasource.password = ${DB_PASSWORD}
 
 springdoc.show-actuator=false
 springdoc.swagger-ui.path=/docs


### PR DESCRIPTION
Para desarrollar: 

* Se puede levantar el servicio y la base localmente con docker compose, corriendo ```./run_dev.sh```

* Se puede levantar el servicio, sin docker, y que le pegue a la base de dev hosteada en atlas ```./run_dev_atlas_db.sh```
